### PR TITLE
GitHub Action to run tests on JDK 8, 11, 13

### DIFF
--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -9,7 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]  # , macos-latest
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        # macos-latest disabled because of actions/setup-java#77
+        # windows-latest because of failing \\character tests
+        os: [ubuntu-latest]
         java: [8, 11, 13]  # See .travis.yml for failures on JDK12, JDK14
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -1,0 +1,19 @@
+name: java_tests
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  java_tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [8, 11, 14]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - run: |
+           ant developer-build
+           ant regrtest-travis

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -7,8 +7,9 @@ jobs:
   java_tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]  # , macos-latest
         java: [8, 11, 14]
     steps:
       - uses: actions/checkout@v2
@@ -16,5 +17,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - run: |
+           java -version
            ant developer-build
            ant regrtest-travis

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -10,13 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]  # , macos-latest
-        java: [8, 11, 14]
+        java: [8, 11, 13]  # See .travis.yml for failures on JDK12, JDK14
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - run: |
-           java -version
-           ant developer-build
-           ant regrtest-travis
+      - run: java -version ; ant -version
+      - run: ant developer-build
+      - run: ant regrtest-travis

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -5,10 +5,11 @@ on:
   #  branches: [master]
 jobs:
   java_tests:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [8, 11, 14]
+        java-version: [8, 11, 14]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java-version: [8, 11, 14]
+        java: [8, 11, 14]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1


### PR DESCRIPTION
Output: https://github.com/cclauss/jython-1/actions as suggested in jython/frozen-mirror#187

macOS is blocked by actions/setup-java#77

GitHub Actions seems faster than Travis CI especially in job startup.