### PR TITLE
pickletester.py: tolerate times being off by 1 sec

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -636,7 +636,6 @@ class AbstractPickleTests(unittest.TestCase):
     def test_structseq(self):
         import time
         import os
-        from math import isclose
 
         t = time.localtime()
         for proto in protocols:
@@ -647,9 +646,12 @@ class AbstractPickleTests(unittest.TestCase):
                 t = os.stat(os.curdir)
                 s = self.dumps(t, proto)
                 u = self.loads(s)
-                # self.assertEqual(t, u)  # tolerate times being off by 1 second.
-                self.assertTrue(all(isclose(t[key], value)
-                                    for key, value in u.items()))
+                try:  # tolerate times being off by 1 second.
+                    from math import isclose  # added in Python 3.5
+                    self.assertTrue(all(isclose(t[key], value)
+                                        for key, value in u.items()))
+                except ImportError:
+                    self.assertEqual(t, u)
             if hasattr(os, "statvfs"):
                 t = os.statvfs(os.curdir)
                 s = self.dumps(t, proto)

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -636,6 +636,7 @@ class AbstractPickleTests(unittest.TestCase):
     def test_structseq(self):
         import time
         import os
+        from math import isclose
 
         t = time.localtime()
         for proto in protocols:
@@ -646,7 +647,8 @@ class AbstractPickleTests(unittest.TestCase):
                 t = os.stat(os.curdir)
                 s = self.dumps(t, proto)
                 u = self.loads(s)
-                self.assertEqual(t, u)
+                # self.assertEqual(t, u)  # tolerate times being off by 1 second.
+                self.assertTrue(isclose(t[key], value) for key, value in u.items())
             if hasattr(os, "statvfs"):
                 t = os.statvfs(os.curdir)
                 s = self.dumps(t, proto)

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -648,7 +648,8 @@ class AbstractPickleTests(unittest.TestCase):
                 s = self.dumps(t, proto)
                 u = self.loads(s)
                 # self.assertEqual(t, u)  # tolerate times being off by 1 second.
-                self.assertTrue(isclose(t[key], value) for key, value in u.items())
+                self.assertTrue(all(isclose(t[key], value)
+                                    for key, value in u.items()))
             if hasattr(os, "statvfs"):
                 t = os.statvfs(os.curdir)
                 s = self.dumps(t, proto)


### PR DESCRIPTION
As discussed at https://github.com/jython/jython/pull/38#issuecomment-646494151 use [`math.isclose()`](https://docs.python.org/3/library/math.html#math.isclose) to tolerate time fields being off by 1 sec which happens in some tests such as:
```
Use 'regrtest.py -u xpickle' to run them.
test test_xpickle failed -- Traceback (most recent call last):
  File "/home/runner/work/jython-1/jython-1/dist/Lib/test/pickletester.py", line 649, in test_structseq
    self.assertEqual(t, u)
AssertionError: posix.stat_result(st_mode=16877, st_ino=1845292, st_dev=2065L, st_nlink=23, st_uid=1001, st_gid=116, st_size=4096, st_atime=1592240210, st_mtime=1592240209, st_ctime=1592240209) != posix.stat_result(st_mode=16877, st_ino=1845292, st_dev=2065L, st_nlink=23, st_uid=1001, st_gid=116, st_size=4096, st_atime=1592240210, st_mtime=1592240210, st_ctime=1592240210)
```