### PR TITLE
Handle IndexError from embedded interpreter

### DIFF
--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -224,7 +224,7 @@ def warn(message, category=None, stacklevel=1):
         if module == "__main__":
             try:
                 filename = sys.argv[0]
-            except (AttributeError, TypeError):
+            except (AttributeError, TypeError, IndexError):
                 # embedded interpreters don't have sys.argv, see bug #839151
                 filename = '__main__'
         if not filename:


### PR DESCRIPTION
In my environment we are using a Jython Interpreter embedded in a larger application.  After upgrading from a much older version to 2.7.2 we started getting an IndexError that hosed things.  The comment below the modified line notes that sys.argv isn't handled properly in embedded interpreters I suspect that there was a change alsewhere that changed sys.argv from being undefined to being an empty list but that is just speculation.  Regardless this change gets things working in our embedded environment.